### PR TITLE
Fix update of last order import date

### DIFF
--- a/models/sale_order.py
+++ b/models/sale_order.py
@@ -60,7 +60,11 @@ class SaleOrder(models.Model):
                     break
             if all_orders:
                 orders = self.create_shopify_order(all_orders, shopify_instance_id, skip_existing_order, status='draft')
-                shopify_instance_id.shopify_last_date_order_import = fields.Datetime.now()
+                if len(all_orders) >= params.get('limit', 0):
+                    last_dt = parser.isoparse(all_orders[-1].get('created_at'))
+                    shopify_instance_id.shopify_last_date_order_import = last_dt.astimezone(utc)
+                else:
+                    shopify_instance_id.shopify_last_date_order_import = fields.Datetime.now()
                 return orders
             else:
                 _logger.info("No draft orders found in Shopify.")
@@ -449,10 +453,9 @@ class SaleOrder(models.Model):
                 
             # Configurar parámetros para la consulta a Shopify
             params = {
-                "limit": 1,  # Ajusta el tamaño de página según sea necesario
+                "limit": 250,  # Ajusta el tamaño de página según sea necesario
                 "pageInfo": None,
-                "status": "any",
-                "ids":"11621606326620"
+                "status": "any"
             }
             if effective_from_date:
                 params["created_at_min"] = effective_from_date
@@ -478,7 +481,11 @@ class SaleOrder(models.Model):
                 _logger.info(f"WSSH Found {len(all_orders)} para {shopify_instance_id.name}")
                 orders = self.create_shopify_order(all_orders, shopify_instance_id, skip_existing_order, status='open')
                 orders_total.extend(orders)
-                shopify_instance_id.shopify_last_date_order_import = fields.Datetime.now()
+                if len(all_orders) >= params.get('limit', 0):
+                    last_dt = parser.isoparse(all_orders[-1].get('created_at'))
+                    shopify_instance_id.shopify_last_date_order_import = last_dt.astimezone(utc)
+                else:
+                    shopify_instance_id.shopify_last_date_order_import = fields.Datetime.now()
             else:
                 _logger.info(f"WSSH No orders found in shopify {shopify_instance_id.name}")
                 

--- a/wizard/shopify_operation.py
+++ b/wizard/shopify_operation.py
@@ -93,7 +93,6 @@ class ShopifyOperation(models.TransientModel):
                                                                   self.orders_from_date,
                                                                   self.orders_to_date)
             if orders:
-                self.shopify_instance_id.shopify_last_date_order_import = datetime.now()
                 ids = orders
                 action_name = "ws_shopify.action_sale_order_shopify"
 


### PR DESCRIPTION
## Summary
- adjust date update logic when importing draft orders and orders
- avoid resetting last import date in wizard

## Testing
- `python -m py_compile models/sale_order.py wizard/shopify_operation.py`

------
https://chatgpt.com/codex/tasks/task_e_6866790cb2d88323be3bd917e1a5ddd5