### PR TITLE
Fix update after all Shopify variants removed

### DIFF
--- a/models/product.py
+++ b/models/product.py
@@ -848,6 +848,15 @@ class ProductTemplate(models.Model):
                                             ]
                                             variants -= removed_variants
                                             new_variants -= removed_variants
+
+                                            # Si no quedan variantes a actualizar o crear,
+                                            # no tiene sentido enviar un payload vacío
+                                            if not variant_data:
+                                                _logger.warning(
+                                                    f"WSSH All variants removed for product {product_map.web_product_id}; skipping update")
+                                                product_processed = True
+                                                break
+
                                             product_data['product']['variants'] = variant_data
                                             retries += 1
                                             _logger.info(


### PR DESCRIPTION
## Summary
- skip update if all variants were removed after a 422 error

## Testing
- `python -m py_compile models/product.py`

------
https://chatgpt.com/codex/tasks/task_e_688cfa246acc83239697428e61454617