### PR TITLE
Assign product after creating variant mapping

### DIFF
--- a/models/sale_order.py
+++ b/models/sale_order.py
@@ -276,6 +276,8 @@ class SaleOrder(models.Model):
                                     'odoo_id': product_by_sku.id,
                                     'shopify_instance_id': shopify_instance_id.id,
                                 })
+                            product = product_by_sku
+                            product_name = line.get('title') + ' ' + sku
 
                 if not product:
                     # Buscar/crear por nombre si no se encontró por SKU


### PR DESCRIPTION
## Summary
- Ensure the product variable is set after creating a variant mapping so Shopify order import links to the correct product

## Testing
- `python -m compileall .`


------
https://chatgpt.com/codex/tasks/task_e_68a58692141c832398dc48bfe810b09e